### PR TITLE
feat(tauri): improve desktop startup and diagnostics

### DIFF
--- a/frontend/app/ready/route.ts
+++ b/frontend/app/ready/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+	const proxyBaseUrl =
+		process.env.API_REWRITE_URL || process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8100";
+	const targetUrl = `${proxyBaseUrl.replace(/\/$/, "")}/ready`;
+
+	try {
+		const response = await fetch(targetUrl, {
+			cache: "no-store",
+			headers: {
+				accept: "application/json",
+			},
+		});
+		const contentType = response.headers.get("content-type") || "application/json";
+		const body = await response.text();
+
+		return new NextResponse(body, {
+			status: response.status,
+			headers: {
+				"content-type": contentType,
+				"cache-control": "no-store",
+			},
+		});
+	} catch (error) {
+		return NextResponse.json(
+			{
+				status: "error",
+				message: error instanceof Error ? error.message : String(error),
+			},
+			{
+				status: 503,
+				headers: {
+					"cache-control": "no-store",
+				},
+			},
+		);
+	}
+}

--- a/frontend/apps/settings/components/DesktopServerSection.tsx
+++ b/frontend/apps/settings/components/DesktopServerSection.tsx
@@ -3,14 +3,21 @@
 import { useEffect, useMemo, useState } from "react";
 import { type DesktopSettings, getDesktopSettings, updateDesktopSettings } from "@/lib/desktop-settings";
 import { toastError, toastSuccess } from "@/lib/toast";
-import { isTauri } from "@/lib/utils/platform";
+import { getPlatform, isTauri } from "@/lib/utils/platform";
 import { SettingsSection } from "./SettingsSection";
 
 export function DesktopServerSection() {
 	const [settings, setSettings] = useState<DesktopSettings | null>(null);
 	const [draftUrl, setDraftUrl] = useState("");
 	const [saving, setSaving] = useState(false);
+	const [platform, setPlatform] = useState("unknown");
 	const isDesktopTauri = isTauri();
+	const runtimeBackendUrl =
+		typeof window !== "undefined" ? window.__BACKEND_URL__ || "" : "";
+
+	useEffect(() => {
+		setPlatform(getPlatform());
+	}, []);
 
 	useEffect(() => {
 		if (!isDesktopTauri) {
@@ -33,10 +40,6 @@ export function DesktopServerSection() {
 	const hasChanges = useMemo(() => {
 		return draftUrl.trim().replace(/\/$/, "") !== (settings?.apiBaseUrl || "");
 	}, [draftUrl, settings?.apiBaseUrl]);
-
-	if (!isDesktopTauri) {
-		return null;
-	}
 
 	const handleSave = async () => {
 		const nextUrl = draftUrl.trim().replace(/\/$/, "");
@@ -62,7 +65,7 @@ export function DesktopServerSection() {
 	return (
 		<SettingsSection
 			title="Desktop server"
-			description="Choose which remote API the Tauri app proxies to."
+			description="Choose which remote API the desktop app proxies to."
 			searchKeywords={[
 				"desktop server",
 				"server url",
@@ -71,6 +74,18 @@ export function DesktopServerSection() {
 			]}
 		>
 			<div className="space-y-3">
+				<div className="rounded-md border border-dashed border-border/70 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+					<div className="font-medium text-foreground/90">Runtime diagnostics</div>
+					<div className="mt-1">Detected platform: {platform}</div>
+					<div className="mt-1 break-all font-mono text-[11px] text-foreground/80">
+						Current runtime backend: {runtimeBackendUrl || "(not set)"}
+					</div>
+					{!isDesktopTauri && (
+						<div className="mt-2 text-amber-300">
+							Tauri runtime was not detected in this window. The section stays visible so you can tell this build is not running as the expected desktop shell.
+						</div>
+					)}
+				</div>
 				<div>
 					<label
 						htmlFor="desktop-server-url"
@@ -85,10 +100,12 @@ export function DesktopServerSection() {
 						placeholder="https://api.example.com"
 						value={draftUrl}
 						onChange={(event) => setDraftUrl(event.target.value)}
-						disabled={saving}
+						disabled={saving || !isDesktopTauri}
 					/>
 					<p className="mt-1 text-xs text-muted-foreground">
-						This updates the local proxy immediately for new requests.
+						{isDesktopTauri
+							? "This updates the local proxy immediately for new requests."
+							: "Save is disabled because this window is not exposing the expected Tauri runtime bridge."}
 					</p>
 				</div>
 				<div className="rounded-md border border-dashed border-border/70 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
@@ -102,7 +119,7 @@ export function DesktopServerSection() {
 						type="button"
 						className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
 						onClick={() => setDraftUrl(settings?.apiBaseUrl || "")}
-						disabled={saving || !hasChanges}
+						disabled={saving || !hasChanges || !isDesktopTauri}
 					>
 						Reset
 					</button>
@@ -110,7 +127,7 @@ export function DesktopServerSection() {
 						type="button"
 						className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
 						onClick={handleSave}
-						disabled={saving || !hasChanges}
+						disabled={saving || !hasChanges || !isDesktopTauri}
 					>
 						{saving ? "Saving..." : "Save"}
 					</button>

--- a/frontend/apps/settings/components/DesktopServerSection.tsx
+++ b/frontend/apps/settings/components/DesktopServerSection.tsx
@@ -14,6 +14,10 @@ export function DesktopServerSection() {
 	const isDesktopTauri = isTauri();
 	const runtimeBackendUrl =
 		typeof window !== "undefined" ? window.__BACKEND_URL__ || "" : "";
+	const runtimeFrontendOrigin =
+		typeof window !== "undefined" ? window.location.origin || "" : "";
+	const runtimeFrontendPort =
+		typeof window !== "undefined" ? window.location.port || "" : "";
 
 	useEffect(() => {
 		setPlatform(getPlatform());
@@ -77,6 +81,10 @@ export function DesktopServerSection() {
 				<div className="rounded-md border border-dashed border-border/70 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
 					<div className="font-medium text-foreground/90">Runtime diagnostics</div>
 					<div className="mt-1">Detected platform: {platform}</div>
+					<div className="mt-1 break-all font-mono text-[11px] text-foreground/80">
+						Current local frontend: {runtimeFrontendOrigin || "(not set)"}
+					</div>
+					<div className="mt-1">Connected local port: {runtimeFrontendPort || "(none)"}</div>
 					<div className="mt-1 break-all font-mono text-[11px] text-foreground/80">
 						Current runtime backend: {runtimeBackendUrl || "(not set)"}
 					</div>

--- a/frontend/components/common/ui/BackendReadyGate.tsx
+++ b/frontend/components/common/ui/BackendReadyGate.tsx
@@ -10,8 +10,7 @@ interface BackendReadyGateProps {
 }
 
 function getBackendHealthUrl(): string {
-	const baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8100";
-	return `${baseUrl}/ready`;
+	return "/ready";
 }
 
 export function BackendReadyGate({ children }: BackendReadyGateProps) {

--- a/frontend/lib/utils/platform.ts
+++ b/frontend/lib/utils/platform.ts
@@ -9,7 +9,16 @@
  * Check if running in Tauri environment
  */
 export const isTauri = (): boolean => {
-  return typeof window !== 'undefined' && '__TAURI__' in window;
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const tauriWindow = window as Window & {
+    __TAURI__?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+  };
+
+  return '__TAURI__' in tauriWindow || '__TAURI_INTERNALS__' in tauriWindow;
 };
 
 /**

--- a/frontend/scripts/tauri-prebuild.js
+++ b/frontend/scripts/tauri-prebuild.js
@@ -4,6 +4,16 @@ const { execSync } = require("node:child_process");
 
 const distDir = path.join(__dirname, "..", "src-tauri", "dist");
 const indexPath = path.join(distDir, "index.html");
+const rootDir = path.join(__dirname, "..");
+
+let buildToken = String(Date.now());
+try {
+	buildToken = `${execSync("git rev-parse --short HEAD", { cwd: rootDir })
+		.toString()
+		.trim()}-${Date.now().toString(36)}`;
+} catch {
+	// Fall back to a timestamp token when git is unavailable.
+}
 
 fs.mkdirSync(distDir, { recursive: true });
 
@@ -69,6 +79,7 @@ const html = `<!doctype html>
       const maxAttempts = 50;
       const retryDelayMs = 600;
       const maxWaitMs = 30000;
+      const buildToken = ${JSON.stringify(buildToken)};
 
       const startTime = Date.now();
 
@@ -85,7 +96,7 @@ const html = `<!doctype html>
         const url = "http://localhost:" + port;
         const ok = await isServerUp(url);
         if (ok) {
-          window.location.replace(url);
+          window.location.replace(url + "/?appBuild=" + encodeURIComponent(buildToken));
           return true;
         }
         return false;
@@ -125,7 +136,6 @@ function copyDir(src, dest) {
 	fs.cpSync(src, dest, { recursive: true, force: true });
 }
 
-const rootDir = path.join(__dirname, "..");
 const nextDir = path.join(rootDir, ".next");
 const standaloneDir = path.join(nextDir, "standalone");
 

--- a/frontend/scripts/tauri-prebuild.js
+++ b/frontend/scripts/tauri-prebuild.js
@@ -92,7 +92,7 @@ const html = `<!doctype html>
       }
 
       async function poll() {
-        for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        for (let attempt = maxAttempts - 1; attempt >= 0; attempt -= 1) {
           const port = startPort + attempt;
           const ready = await tryPort(port);
           if (ready) {

--- a/frontend/src-tauri/src/nextjs.rs
+++ b/frontend/src-tauri/src/nextjs.rs
@@ -127,6 +127,43 @@ fn get_server_path(app: &AppHandle) -> Result<PathBuf, String> {
     Err(format!("Server file not found under {:?}", resource_path))
 }
 
+#[cfg(unix)]
+fn cleanup_stale_nextjs_servers() {
+    let patterns = [
+        "FreeTodo.app/Contents/Resources/standalone/server.js",
+        "FreeTodo.app/Contents/Resources/_up_/.next/standalone/server.js",
+        "FreeTodo.app/Contents/Resources/.next/standalone/server.js",
+    ];
+
+    for pattern in patterns {
+        match Command::new("pkill").args(["-f", pattern]).output() {
+            Ok(output) if output.status.success() => {
+                info!(
+                    "Stopped stale FreeTodo frontend servers matching pattern: {}",
+                    pattern
+                );
+            }
+            Ok(output) if output.status.code() == Some(1) => {}
+            Ok(output) => {
+                warn!(
+                    "Failed to stop stale frontend servers for pattern {}: {}",
+                    pattern,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Err(err) => {
+                warn!(
+                    "Failed to run pkill for stale frontend cleanup ({}): {}",
+                    pattern, err
+                );
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn cleanup_stale_nextjs_servers() {}
+
 /// Start the Next.js server
 pub async fn start_nextjs(app: &AppHandle) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // In development mode, expect external dev server
@@ -160,6 +197,8 @@ pub async fn start_nextjs(app: &AppHandle) -> Result<(), Box<dyn std::error::Err
 
     // Production mode: start standalone server
     info!("Starting Next.js production server...");
+
+    cleanup_stale_nextjs_servers();
 
     // Get server path
     let server_path = get_server_path(app)?;


### PR DESCRIPTION
## Summary
- improve Tauri desktop startup by detecting the runtime without relying on a global bridge and by preferring the newest local frontend server
- add cleanup and startup guards for stale frontend processes so the desktop shell recovers more reliably on launch
- surface desktop server diagnostics and the connected local frontend port in settings for easier troubleshooting

## Testing
- Not run (not requested)