### PR TITLE
fix(backend): restore agno chat module import path

### DIFF
--- a/docs/guides/deployment/deploy_in_local.md
+++ b/docs/guides/deployment/deploy_in_local.md
@@ -293,3 +293,25 @@ ipconfig | findstr "IPv4"
 ### 9.5 端口被占用
 
 如果 8001 端口被占用，可修改 `server/config/config.yaml` 中的 `server.port`，同时更新 `frontend/.env` 和 Client 启动参数中的端口号。
+
+### 9.6 Frontend TypeScript 报错：Cannot find module `../../app/ready/route.js`
+
+该错误通常由 Next.js 路由类型缓存过期导致（`.next/types/validator.ts` 引用了已删除的路由）。
+
+可在 `frontend/` 目录重新生成类型：
+
+```bash
+pnpm exec next typegen
+```
+
+或在仓库根目录执行：
+
+```bash
+pnpm --dir frontend exec next typegen
+```
+
+生成完成后再次运行：
+
+```bash
+pnpm --dir frontend type-check
+```

--- a/server/routers/chat/modes/agno.py
+++ b/server/routers/chat/modes/agno.py
@@ -6,7 +6,8 @@ from typing import Any
 
 from fastapi.responses import StreamingResponse
 
-from llm.agno_agent import TOOL_EVENT_PREFIX, TOOL_EVENT_SUFFIX, AgnoAgentService
+from llm.agno_agent import AgnoAgentService
+from llm.agno_agent_io import TOOL_EVENT_PREFIX, TOOL_EVENT_SUFFIX
 from llm.agno_tools.memory_toolkit import MemoryToolkit
 from routers.chat.base import _schedule_preference_extraction, publish_ai_output_to_perception
 from schemas.chat import ChatMessage


### PR DESCRIPTION
## Summary
- Fix Agno chat mode import path by loading `TOOL_EVENT_PREFIX` and `TOOL_EVENT_SUFFIX` from `llm.agno_agent_io`, so the `chat` module can register successfully at server startup.
- Keep `AgnoAgentService` import from `llm.agno_agent` unchanged.
- Update local deployment troubleshooting docs with a fix for stale Next.js route type cache (`Cannot find module ../../app/ready/route.js`).

## Testing
- `uv run --directory server python -c "import routers.chat.modes.agno as agno; print('agno import ok')"`
- `pnpm --dir frontend type-check`