### PR TITLE
fix(backend): support ~ expansion in workspace path validation

### DIFF
--- a/docs/plans/远期修正列表.md
+++ b/docs/plans/远期修正列表.md
@@ -12,11 +12,6 @@
 
 ## 已修正
 
-### 2. workspace 路径不支持 `~` 展开 — 2026-03-28 已修复
-
-- `server/routers/chat/helpers.py` 的 `validate_workspace_path` 在解析路径时缺少 `expanduser()` 调用，导致含 `~` 的路径（如 `~/Projects`）验证失败
-- 修复方式：在 `Path(workspace_path).resolve()` 前插入 `.expanduser()`
-
 ### 1. 时区未对齐到东八区（Asia/Shanghai） — 2026-03-02 已修复
 
 - 在 `time_utils.py` 新增 `USER_TIMEZONE`（UTC+8）、`get_local_now()`、`local_today_str()`、`local_yesterday_str()`

--- a/docs/plans/远期修正列表.md
+++ b/docs/plans/远期修正列表.md
@@ -12,6 +12,11 @@
 
 ## 已修正
 
+### 2. workspace 路径不支持 `~` 展开 — 2026-03-28 已修复
+
+- `server/routers/chat/helpers.py` 的 `validate_workspace_path` 在解析路径时缺少 `expanduser()` 调用，导致含 `~` 的路径（如 `~/Projects`）验证失败
+- 修复方式：在 `Path(workspace_path).resolve()` 前插入 `.expanduser()`
+
 ### 1. 时区未对齐到东八区（Asia/Shanghai） — 2026-03-02 已修复
 
 - 在 `time_utils.py` 新增 `USER_TIMEZONE`（UTC+8）、`get_local_now()`、`local_today_str()`、`local_yesterday_str()`

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/server/routers/chat/helpers.py
+++ b/server/routers/chat/helpers.py
@@ -130,7 +130,7 @@ def validate_workspace_path(workspace_path: str) -> tuple[bool, str]:
         (is_valid, error_message) 元组
     """
     try:
-        workspace = Path(workspace_path).resolve()
+        workspace = Path(workspace_path).expanduser().resolve()
     except Exception as e:
         return False, f"无效的路径: {e}"
 


### PR DESCRIPTION
Add expanduser() before resolve() in validate_workspace_path so paths like ~/Projects are correctly resolved instead of being rejected.

Made-with: Cursor